### PR TITLE
Write proper EDN to resources/deploy-info.edn

### DIFF
--- a/src/leiningen/git_info_edn.clj
+++ b/src/leiningen/git_info_edn.clj
@@ -1,16 +1,13 @@
 (ns leiningen.git-info-edn
-  (:require [clojure.java.shell :as sh]
-            [clojure.string :as string])
+  (:require [clojure.java.shell :as sh])
   (:import (java.util Date)))
 
 (defn git-info-edn
   "adds git info to the resources directory"
   [& _]
   (spit "resources/deploy-info.edn"
-        (string/join \newline
-                     (map (partial apply print-str)
-                          {:hash (:out (sh/sh "git" "rev-parse" "HEAD"))
-                           :status (:out (sh/sh "git" "status"))
-                           :date (Date.)
-                           \space \space})))
+    (pr-str
+      {:hash (:out (sh/sh "git" "rev-parse" "HEAD"))
+       :status (:out (sh/sh "git" "status"))
+       :date (Date.)}))
   true)


### PR DESCRIPTION
Here's my suggestion in order to keep the contents of deploy-info as proper EDN, making it possible to do (-> (slurp "resources/deploy-info.edn) clojure.edn/read-str).
